### PR TITLE
Init the FastAPI app inside the fastapi_babel

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,11 +130,10 @@ if __name__ == "__main__":
 ```python
 from fastapi import FastAPI, Request
 from fastapi_babel import _
-from fastapi_babel.middleware import InternationalizationMiddleware as I18nMiddleware
 from .babel import babel
 
 app = FastAPI()
-app.add_middleware(I18nMiddleware, babel=babel)
+babel.init_app(app)
 
 @app.get("/items/{id}", response_class=HTMLResponse)
 async def read_item(request: Request, id: str):
@@ -167,7 +166,6 @@ from fastapi import FastAPI, Request
 from fastapi_babel import Babel
 from fastapi_babel import BabelConfigs
 from fastapi_babel import _
-from fastapi_babel.middleware import InternationalizationMiddleware as I18nMiddleware
 
 from fastapi.responses import HTMLResponse
 from fastapi.staticfiles import StaticFiles
@@ -179,11 +177,9 @@ configs = BabelConfigs(
     BABEL_DEFAULT_LOCALE="en",
     BABEL_TRANSLATION_DIRECTORY="lang",
 )
-babel = Babel(configs=configs)
-babel.install_jinja(templates)
 
 app = FastAPI()
-app.add_middleware(I18nMiddleware, babel=babel)
+babel = Babel(app, configs=configs)
 app.mount("/static", StaticFiles(directory="static"), name="static")
 
 @app.get("/items/{id}", response_class=HTMLResponse)

--- a/examples/test1/main.py
+++ b/examples/test1/main.py
@@ -3,9 +3,6 @@ from fastapi import FastAPI, Request
 from fastapi_babel import Babel
 from fastapi_babel import BabelConfigs
 from fastapi_babel import _
-from fastapi_babel.middleware import (
-    InternationalizationMiddleware as I18nMiddleware
-    )
 
 
 configs = BabelConfigs(
@@ -13,15 +10,15 @@ configs = BabelConfigs(
     BABEL_DEFAULT_LOCALE="en",
     BABEL_TRANSLATION_DIRECTORY="lang",
 )
-babel = Babel(configs=configs)
 
 app = FastAPI()
-app.add_middleware(I18nMiddleware, babel=babel)
+babel = Babel(app, configs=configs)
+
 
 @app.get("/items/{id}")
 async def read_item(request: Request, id: str):
     return {
-        "id": id, 
-        "message": _("Hello World"), 
-        "locale": request.headers.get("Accept-Language")
-        }
+        "id": id,
+        "message": _("Hello World"),
+        "locale": request.headers.get("Accept-Language"),
+    }

--- a/examples/with_jinja/full.py
+++ b/examples/with_jinja/full.py
@@ -15,12 +15,12 @@ configs = BabelConfigs(
     BABEL_DEFAULT_LOCALE="en",
     BABEL_TRANSLATION_DIRECTORY="lang",
 )
-babel = Babel(configs=configs)
-babel.install_jinja(templates)
 
 app = FastAPI()
-app.add_middleware(I18nMiddleware, babel=babel)
+babel = Babel(app, configs=configs)
+babel.install_jinja(templates)
 app.mount("/static", StaticFiles(directory="static"), name="static")
+
 
 @app.get("/items/{id}", response_class=HTMLResponse)
 async def read_item(request: Request, id: str):

--- a/fastapi_babel/middleware.py
+++ b/fastapi_babel/middleware.py
@@ -3,14 +3,18 @@ from starlette.middleware.base import BaseHTTPMiddleware
 from starlette.middleware.base import RequestResponseEndpoint
 from starlette.middleware.base import DispatchFunction
 from starlette.types import ASGIApp
-from .core import Babel
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from .core import Babel
+
 
 class InternationalizationMiddleware(BaseHTTPMiddleware):
     def __init__(
-        self, app: ASGIApp, babel: Babel, dispatch: DispatchFunction = None
+        self, app: ASGIApp, babel: "Babel", dispatch: DispatchFunction = None
     ) -> None:
         super().__init__(app, dispatch)
-        self.babel: Babel = babel
+        self.babel: "Babel" = babel
 
     async def dispatch(
         self, request: Request, call_next: RequestResponseEndpoint


### PR DESCRIPTION
setting up middleware in the main app file is a little redundant, so:

- add `Babel.init_app` method to setup the middleware inside the fastapi_babel
- update `Babel.__init__` to accept `the app: FastAPI` optional first argument to init the middleware
	because of this, the `configs` argument is now keyword only, and it shouldn't be a problem.
- update examples
- update README