### PR TITLE
Implemented request scoped translations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -109,6 +109,7 @@ ipython_config.py
 #   https://pdm.fming.dev/#use-with-ide
 .pdm.toml
 .vscode
+.idea
 # PEP 582; used by e.g. github.com/David-OConnor/pyflow and github.com/pdm-project/pdm
 __pypackages__/
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 # FastAPI BABEL
 ### Get [pybabbel](https://github.com/python-babel/babel) tools directly within your FastAPI project without hassle.
 
-FastAPI Babel is will be integrated within FastAPI framework and gives you support of i18n, l10n, date and time locales and all other pybabel functionalities.
+FastAPI Babel is integrated within FastAPI framework and gives you support of i18n, l10n, date and time locales and all other pybabel functionalities.
 
 ## Features:
 - **I18n** (Internationalization)
@@ -40,8 +40,7 @@ and
 2. make `babel.py` file:
 
 ```python
-from fastapi_babel import Babel
-from fastapi_babel import BabelConfigs
+from fastapi_babel import Babel, BabelConfigs
 
 configs = BabelConfigs(
     ROOT_DIR=__file__,
@@ -64,9 +63,7 @@ if __name__ == "__main__":
 4. Create main.py file:
 
 ```python
-from fastapi_babel import Babel
-from fastapi_babel import BabelConfigs
-from fastapi_babel import _
+from fastapi_babel import Babel, BabelConfigs, _
 
 configs = BabelConfigs(
     ROOT_DIR=__file__,
@@ -88,11 +85,11 @@ if __name__ == "__main__":
     main()
 ```
 
-5. Extract the massage <a name="step5"></a>
+5. Extract the message <a name="step5"></a>
 
 `pybabel extract -F babel.cfg -o messages.pot .`
 
-6. Initialize pybabble
+6. Initialize pybabel
 
 `pybabel init -i messages.pot -d lang -l fa`
 
@@ -105,8 +102,6 @@ if __name__ == "__main__":
 9. Run `main.py`
 
 `python3 main.py`
-
-10. Enjoy
 
 - ### FastAPI Babel Commands
 Install click at first:
@@ -124,7 +119,7 @@ babel.run_cli()
 For more information just take a look at help flag of `main.py`
 `python main.py --help`
 
-#### Why FastAPI Babel CLI is recommanded ?
+#### Why FastAPI Babel CLI is recommended ?
 FastAPI Babel CLI will eliminate the need of concering the directories and paths, so you can concentrate on the project and spend less time on going forward and backward. You only need to specify **domain name**, **babel.cfg** and** localization directory **.
 
 **NOTICE:** Do **not** use `FastAPI Babbel` beside fastapi runner files (`main.py` or `run.py`), as uvicorn cli will not work.
@@ -137,32 +132,31 @@ FastAPI Babel CLI will eliminate the need of concering the directories and paths
 - create file `babel.py` and write the code below.
 
 ```python
-from fastapi_babel import Babel
-from fastapi_babel import BabelConfigs
+from fastapi_babel import Babel, BabelConfigs, BabelMiddleware 
 
 configs = BabelConfigs(
     ROOT_DIR=__file__,
     BABEL_DEFAULT_LOCALE="en",
     BABEL_TRANSLATION_DIRECTORY="lang",
 )
-babel = Babel(configs=configs)
+app.add_middleware(BabelMiddleware, babel_configs=configs)
 
 if __name__ == "__main__":
-    babel.run_cli()
+    Babel(configs).run_cli()
 ```
 1. Extract messages with following command
 
 `python3 babel.py extract -d/--dir {watch_dir}`
 
-**Notice: ** watch_dir is your project root directory, or where you want to extract the messages into that directory.
+**Notice: ** watch_dir is your project root directory, where the messages will be extracted.
 
-2. add your own langauge locale directory, for instance `fa`.
+2. Add your own language locale directory, for instance `fa`.
 
 `python3 babel.py init -l fa`
 
-3. go to ./lang/Fa/.po and add your translations.
+3. Go to ./lang/Fa/.po and add your translations.
 
-4. compile all locale directorties.
+4. compile all locale directories.
 `python3 babel.py compile`
 
 ```python
@@ -171,7 +165,11 @@ from fastapi_babel import _
 from .babel import babel
 
 app = FastAPI()
-babel.init_app(app)
+app.add_middleware(BabelMiddleware, babel_configs=BabelConfigs(
+    ROOT_DIR=__file__,
+    BABEL_DEFAULT_LOCALE="en",
+    BABEL_TRANSLATION_DIRECTORY="lang",
+))
 
 @app.get("/items/{id}", response_class=HTMLResponse)
 async def read_item(request: Request, id: str):
@@ -201,26 +199,20 @@ extensions=jinja2.ext.autoescape,jinja2.ext.with_
 *main.py*
 
 ```python
-from fastapi import FastAPI, Request
-
-from fastapi_babel import Babel
-from fastapi_babel import BabelConfigs
-from fastapi_babel import _
-
+from fastapi_babel import Babel, BabelConfigs, BabelMiddleware, _
 from fastapi.responses import HTMLResponse
 from fastapi.staticfiles import StaticFiles
 from fastapi.templating import Jinja2Templates
-
-templates = Jinja2Templates(directory="templates")
-configs = BabelConfigs(
-    ROOT_DIR=__file__,
-    BABEL_DEFAULT_LOCALE="en",
-    BABEL_TRANSLATION_DIRECTORY="lang",
-)
+from fastapi import FastAPI, Request
 
 app = FastAPI()
-babel = Babel(app, configs=configs)
-babel.install_jinja(templates)
+babel_configs = BabelConfigs(
+        ROOT_DIR=__file__,
+        BABEL_DEFAULT_LOCALE="en",
+        BABEL_TRANSLATION_DIRECTORY="lang",
+)
+templates = Jinja2Templates(directory="templates")
+app.add_middleware(BabelMiddleware, babel_configs=babel_configs, jinja2_templates=templates)
 app.mount("/static", StaticFiles(directory="static"), name="static")
 
 @app.get("/items/{id}", response_class=HTMLResponse)

--- a/examples/with_jinja/full.py
+++ b/examples/with_jinja/full.py
@@ -6,16 +6,15 @@ from fastapi.templating import Jinja2Templates
 from fastapi_babel import _  # noqa
 from fastapi_babel import Babel, BabelConfigs
 
-templates = Jinja2Templates(directory="templates")
-configs = BabelConfigs(
-    ROOT_DIR=__file__,
-    BABEL_DEFAULT_LOCALE="en",
-    BABEL_TRANSLATION_DIRECTORY="lang",
-)
 
 app = FastAPI()
-babel = Babel(app, configs=configs)
-babel.install_jinja(templates)
+babel_configs = BabelConfigs(
+        ROOT_DIR=__file__,
+        BABEL_DEFAULT_LOCALE="en",
+        BABEL_TRANSLATION_DIRECTORY="lang",
+)
+templates = Jinja2Templates(directory="templates")
+app.add_middleware(BabelMiddleware, babel_configs=babel_configs, jinja2_templates=templates)
 app.mount("/static", StaticFiles(directory="static"), name="static")
 
 
@@ -25,4 +24,4 @@ async def read_item(request: Request, id: str):
 
 
 if __name__ == "__main__":
-    babel.run_cli()
+    Babel(configs=babel_configs).run_cli()

--- a/examples/wtforms/i18n.py
+++ b/examples/wtforms/i18n.py
@@ -13,5 +13,5 @@ babel = Babel(
 )
 
 if __name__ == "__main__":
-    babel_cli = BabelCli(babel_instance=babel)
+    babel_cli = BabelCli(babel)
     babel_cli.run()

--- a/fastapi_babel/__init__.py
+++ b/fastapi_babel/__init__.py
@@ -1,4 +1,5 @@
 from .core import Babel, BabelCli, _
+from .middleware import BabelMiddleware
 from .properties import RootConfigs as BabelConfigs
 
 __version__ = "0.0.8"

--- a/fastapi_babel/middleware.py
+++ b/fastapi_babel/middleware.py
@@ -1,47 +1,52 @@
 import re
 from fastapi import Request, Response
+from fastapi.templating import Jinja2Templates
 from starlette.middleware.base import BaseHTTPMiddleware
 from starlette.middleware.base import RequestResponseEndpoint
 from starlette.middleware.base import DispatchFunction
 from starlette.types import ASGIApp
 from typing import TYPE_CHECKING, Optional
+from .core import Babel, _context_var
+from .properties import RootConfigs
 from pathlib import Path
 
-if TYPE_CHECKING:
-    from .core import Babel
 
 LANGUAGES_PATTERN = re.compile(r"([a-z]{2})-?([A-Z]{2})?(;q=\d.\d{1,3})?")
 
-class InternationalizationMiddleware(BaseHTTPMiddleware):
+
+class BabelMiddleware(BaseHTTPMiddleware):
     def __init__(
             self,
             app: ASGIApp,
-            babel: "Babel",
+            babel_configs: RootConfigs,
+            jinja2_templates: Jinja2Templates = None,
             dispatch: Optional[DispatchFunction] = None,
     ) -> None:
         super().__init__(app, dispatch)
-        self.babel: "Babel" = babel
+        self.babel_configs = babel_configs
+        self.jinja2_templates = jinja2_templates
 
-    def get_language(self, lang_code):
-        """Applies a available language.
+    def get_language(self, babel: Babel, lang_code):
+        """Applies an available language.
 
-            To apply a available language it will be searched in the language folder for a available one
-            and also it will priotize the one with the highest quality value. The Fallback language will be the
+            To apply an available language it will be searched in the language folder for an available one
+            and will also priotize the one with the highest quality value. The Fallback language will be the
             taken from the BABEL_DEFAULT_LOCALE var.
 
                 Args:
+                    babel (Babel): Request scoped Babel instance
                     lang_code (str): The Value of the Accept-Language Header.
 
                 Returns:
                     str: The language that should be used.
-                """
+        """
         if not lang_code:
-            return self.babel.config.BABEL_DEFAULT_LOCALE
+            return babel.config.BABEL_DEFAULT_LOCALE
 
         matches = re.finditer(LANGUAGES_PATTERN, lang_code)
-        languages = [(f"{m.group(1)}{ f'_{m.group(2)}' if m.group(2) else ''}", m.group(3) or "") for m in matches]
+        languages = [(f"{m.group(1)}{f'_{m.group(2)}' if m.group(2) else ''}", m.group(3) or "") for m in matches]
         languages = sorted(languages, key=lambda x: x[1], reverse=True) # sort the priority, no priority comes last
-        translation_directory = Path(self.babel.config.BABEL_TRANSLATION_DIRECTORY)
+        translation_directory = Path(babel.config.BABEL_TRANSLATION_DIRECTORY)
         translation_files = [i.name for i in translation_directory.iterdir()]
         explicit_priority = None
 
@@ -54,7 +59,7 @@ class InternationalizationMiddleware(BaseHTTPMiddleware):
                     explicit_priority = lang
 
         # Return language with explicit priority or default value
-        return explicit_priority if explicit_priority else self.babel.config.BABEL_DEFAULT_LOCALE
+        return explicit_priority if explicit_priority else self.babel_configs.BABEL_DEFAULT_LOCALE
 
     async def dispatch(
             self, request: Request, call_next: RequestResponseEndpoint
@@ -69,7 +74,13 @@ class InternationalizationMiddleware(BaseHTTPMiddleware):
             Response: ...
         """
         lang_code: Optional[str] = request.headers.get("Accept-Language", None)
-        self.babel.locale = self.get_language(lang_code)
+
+        # Create a new Babel instance per request
+        request.state.babel = Babel(configs=self.babel_configs)
+        request.state.babel.locale = self.get_language(request.state.babel, lang_code)
+        _context_var.set(request.state.babel.gettext)  # Set the _ function in the context variable
+        if self.jinja2_templates:
+            request.state.babel.install_jinja(self.jinja2_templates)
 
         response: Response = await call_next(request)
         return response


### PR DESCRIPTION
There is a serious issue on current implementation, the same Babel instance is shared globally, which means that the request of one user can change the language of another user request depending on race conditions. This PR takes care of scoping a single Babel instance per request.