### PR TITLE
fix README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,7 +193,6 @@ Screenshot:
 ```xml
 [python: **.py]
 [jinja2: **/templates/**.html]
-extensions=jinja2.ext.autoescape,jinja2.ext.with_
 ```
 
 2. Here is how your `main.py` should look like.


### PR DESCRIPTION
With Jinja2 3.1, WithExtension and AutoEscapeExtension are built-in now.  If the extensions are still listed in the .cfg file it will throw an error

https://stackoverflow.com/questions/72651555/attributeerror-module-jinja2-ext-has-no-attribute-autoescape-while-trying-t